### PR TITLE
クレジット変更後デプロイ

### DIFF
--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -12,7 +12,7 @@
           .cardlist__title__container  
             .card-user-info-text
               .card-company-logos
-                = image_tag 'card/visa.jpeg', width: '49', height: '15', alt: 'jcb'
+                = image_tag 'https://www-mercari-jp.akamaized.net/assets/img/card/visa.svg?3761641567', width: '49', height: '15', alt: 'visa'
               .card-information
                 **** **** **** #{@default_card_information.last4}
                 %br

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION
#what  
The asset "card/visa.jpeg" is not present in the asset pipeline.
card/visa.jpegをhttps://www-mercari-jp.akamaized.net/assets/img/card/visa.svg?3761641567へ
変更

#17 画像の中身が無いと言われるから